### PR TITLE
Update license field to use proper SPDX identifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,5 @@ setup(
     keywords='zipfile encryption zip password write writestr',
     packages=['zipencrypt'],
     license="MIT",
-    license-files = ['LICENSE.txt'],
+    license_files = ['LICENSE.txt'],
 )

--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,5 @@ setup(
     keywords='zipfile encryption zip password write writestr',
     packages=['zipencrypt'],
     license="MIT",
-    license_files = ('LICENSE.txt',),
+    license-files = ['LICENSE.txt'],
 )

--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,6 @@ setup(
     ),
     keywords='zipfile encryption zip password write writestr',
     packages=['zipencrypt'],
+    license="MIT",
     license_files = ('LICENSE.txt',),
 )


### PR DESCRIPTION
This changes the license field to be a valid [SPDX identifier](https://spdx.org/licenses) aligning with [PEP 639](https://peps.python.org/pep-0639/#project-source-metadata). This populates the `license_expression` field in the PyPI API and is used by downstream tools including deps.dev

This PR was generated by Claude after reviewing the license and manifest files in your repository, but opened and reviewed by me. Please let me know if the analysis is incorrect and thanks for being an OSS maintainer.